### PR TITLE
chore: remove pnpm reference from deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
       - run: npm install
       - run: npm run build
       - run: npm run docs


### PR DESCRIPTION
We got a "pnpm not found" error when running the docs workflow, probably b/c I copy/pasted this workflow from w3protocol.