### PR TITLE
feat: add uploadCAR method

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ In the example above, `directoryCid` resolves to an IPFS directory with the foll
 - `Client`
   - [`uploadDirectory`](#uploaddirectory)
   - [`uploadFile`](#uploadfile)
+  - [`uploadCAR`](#uploadcar)
   - [`agent`](#agent)
   - [`currentSpace`](#currentspace)
   - [`setCurrentSpace`](#setcurrentspace)
@@ -215,6 +216,7 @@ function uploadDirectory (
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
+    concurrentRequests?: number
   } = {}
 ): Promise<CID>
 ```
@@ -233,11 +235,32 @@ function uploadFile (
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
+    concurrentRequests?: number
   } = {}
 ): Promise<CID>
 ```
 
 Uploads a file to the service and returns the root data CID for the generated DAG.
+
+More information: [`ShardStoredCallback`](#shardstoredcallback)
+
+### `uploadCAR`
+
+```ts
+function uploadCAR (
+  car: Blob,
+  options: {
+    retries?: number
+    signal?: AbortSignal
+    onShardStored?: ShardStoredCallback
+    shardSize?: number
+    concurrentRequests?: number
+    rootCID?: CID
+  } = {}
+): Promise<void>
+```
+
+Uploads a CAR file to the service. The difference between this function and [capability.store.add](#capabilitystoreadd) is that the CAR file is automatically sharded and an "upload" is registered (see [`capability.upload.add`](#capabilityuploadadd)), linking the individual shards. Use the `onShardStored` callback to obtain the CIDs of the CAR file shards.
 
 More information: [`ShardStoredCallback`](#shardstoredcallback)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@ucanto/transport": "^4.0.2",
         "@web3-storage/access": "^9.1.1",
         "@web3-storage/capabilities": "^2.0.0",
-        "@web3-storage/upload-client": "^5.2.0"
+        "@web3-storage/upload-client": "^5.3.0"
       },
       "devDependencies": {
         "@ucanto/server": "^4.0.2",
@@ -394,30 +394,30 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@ucanto/client": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-4.0.2.tgz",
-      "integrity": "sha512-kSAlNlk8lpK2eShsXe9cE2I4iP1a7vq8wIFpzLR8Jjvh0YN4oI3zYQ6grrKJGHrork1mubkqIimzZerHCzFiwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-4.0.3.tgz",
+      "integrity": "sha512-Kr+6A9VB/m2sFEatEKWzJk7Ccwg7AURdqdFyzhzUGU6YvUe4Z/wcly+yz1hswHmGc77dVPo+b19k2U/jjwnSKA==",
       "dependencies": {
-        "@ucanto/interface": "^4.0.2",
+        "@ucanto/interface": "^4.0.3",
         "multiformats": "^10.0.2"
       }
     },
     "node_modules/@ucanto/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-FxR6o4HsJepiYCj21j0F7D2vSPV4z6gk4489oo9NP/uF7+YJdZBSTxPytvBd/Ir7+2xlyFvBXP8Uxx/JRQu9HA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-4.0.3.tgz",
+      "integrity": "sha512-5Uc6vdmKZzlA9NFvAN6BC1Tp1Npz0sepp2up1ZWU4BqArQ0w4U0YMtL9KPdBnL3TDAyDNgS9PgK+vHpjcSoeiQ==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-ucan": "^3.0.1",
-        "@ucanto/interface": "^4.0.2",
+        "@ucanto/interface": "^4.0.3",
         "multiformats": "^10.0.2"
       }
     },
     "node_modules/@ucanto/interface": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-4.0.2.tgz",
-      "integrity": "sha512-3EPO9LRJy9ENWNBLk/x5XOx6ALCzgMkndvdRHJi8VTMKm4XroSnUYLarC3pPLdAWsF7NlmFN4g6aLz4mS9bHUQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-4.0.3.tgz",
+      "integrity": "sha512-ip1ZziMUhi9nFm9jPLEDLs8zX4HleYsuHHITH5w8GjST7chbRz1LBSq43A3nMUgea17cuIp+rr7i4QcOSFgXHw==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.0.1",
         "multiformats": "^10.0.2"
@@ -447,14 +447,14 @@
       }
     },
     "node_modules/@ucanto/transport": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-4.0.2.tgz",
-      "integrity": "sha512-KRWUcmmu6tvVKGO+Q0FnnUcEnIgFNGsQg5Udma+WQrQjJLcd+cDYrz5EhGItMmsC/gtM9Cm2+YMSZL21S/yf9A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-4.0.3.tgz",
+      "integrity": "sha512-yrJoqoxmMCpPElR+iEb2AKIjUEmM+JGCcM1TZLXVbMlzaAt6ndYDMPajfnh3PBQMk7edIodZi+UxCLKvc8yelg==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^4.0.2",
-        "@ucanto/interface": "^4.0.2",
+        "@ucanto/core": "^4.0.3",
+        "@ucanto/interface": "^4.0.3",
         "multiformats": "^10.0.2"
       }
     },
@@ -538,16 +538,16 @@
       }
     },
     "node_modules/@web3-storage/upload-client": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-5.2.0.tgz",
-      "integrity": "sha512-rHx8g56IqGuEdnJW44/SVD8AV1kVE1nzt+gKp4f1hFMMe2FT5eUROk6tM+gQzudrYDkUhhwpzQFmo1FsgohbJQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-5.3.0.tgz",
+      "integrity": "sha512-3vLErJTiigQ/cSlg8mCrOz3ZV1AZeGgeKDvmDhOBSaIY5rBvKzW2Bjcu4Vqv1cLdWOz2qkg6Tp6X+0qRV0cfPA==",
       "dependencies": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-ucan": "^3.0.1",
         "@ipld/unixfs": "^2.0.0",
-        "@ucanto/client": "^4.0.2",
-        "@ucanto/interface": "^4.0.2",
-        "@ucanto/transport": "^4.0.2",
+        "@ucanto/client": "^4.0.3",
+        "@ucanto/interface": "^4.0.3",
+        "@ucanto/transport": "^4.0.3",
         "@web3-storage/capabilities": "^2.1.0",
         "multiformats": "^10.0.2",
         "p-queue": "^7.3.0",
@@ -7250,30 +7250,30 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "@ucanto/client": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-4.0.2.tgz",
-      "integrity": "sha512-kSAlNlk8lpK2eShsXe9cE2I4iP1a7vq8wIFpzLR8Jjvh0YN4oI3zYQ6grrKJGHrork1mubkqIimzZerHCzFiwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-4.0.3.tgz",
+      "integrity": "sha512-Kr+6A9VB/m2sFEatEKWzJk7Ccwg7AURdqdFyzhzUGU6YvUe4Z/wcly+yz1hswHmGc77dVPo+b19k2U/jjwnSKA==",
       "requires": {
-        "@ucanto/interface": "^4.0.2",
+        "@ucanto/interface": "^4.0.3",
         "multiformats": "^10.0.2"
       }
     },
     "@ucanto/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-FxR6o4HsJepiYCj21j0F7D2vSPV4z6gk4489oo9NP/uF7+YJdZBSTxPytvBd/Ir7+2xlyFvBXP8Uxx/JRQu9HA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-4.0.3.tgz",
+      "integrity": "sha512-5Uc6vdmKZzlA9NFvAN6BC1Tp1Npz0sepp2up1ZWU4BqArQ0w4U0YMtL9KPdBnL3TDAyDNgS9PgK+vHpjcSoeiQ==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
         "@ipld/dag-ucan": "^3.0.1",
-        "@ucanto/interface": "^4.0.2",
+        "@ucanto/interface": "^4.0.3",
         "multiformats": "^10.0.2"
       }
     },
     "@ucanto/interface": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-4.0.2.tgz",
-      "integrity": "sha512-3EPO9LRJy9ENWNBLk/x5XOx6ALCzgMkndvdRHJi8VTMKm4XroSnUYLarC3pPLdAWsF7NlmFN4g6aLz4mS9bHUQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-4.0.3.tgz",
+      "integrity": "sha512-ip1ZziMUhi9nFm9jPLEDLs8zX4HleYsuHHITH5w8GjST7chbRz1LBSq43A3nMUgea17cuIp+rr7i4QcOSFgXHw==",
       "requires": {
         "@ipld/dag-ucan": "^3.0.1",
         "multiformats": "^10.0.2"
@@ -7303,14 +7303,14 @@
       }
     },
     "@ucanto/transport": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-4.0.2.tgz",
-      "integrity": "sha512-KRWUcmmu6tvVKGO+Q0FnnUcEnIgFNGsQg5Udma+WQrQjJLcd+cDYrz5EhGItMmsC/gtM9Cm2+YMSZL21S/yf9A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-4.0.3.tgz",
+      "integrity": "sha512-yrJoqoxmMCpPElR+iEb2AKIjUEmM+JGCcM1TZLXVbMlzaAt6ndYDMPajfnh3PBQMk7edIodZi+UxCLKvc8yelg==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-cbor": "^8.0.0",
-        "@ucanto/core": "^4.0.2",
-        "@ucanto/interface": "^4.0.2",
+        "@ucanto/core": "^4.0.3",
+        "@ucanto/interface": "^4.0.3",
         "multiformats": "^10.0.2"
       }
     },
@@ -7386,16 +7386,16 @@
       }
     },
     "@web3-storage/upload-client": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-5.2.0.tgz",
-      "integrity": "sha512-rHx8g56IqGuEdnJW44/SVD8AV1kVE1nzt+gKp4f1hFMMe2FT5eUROk6tM+gQzudrYDkUhhwpzQFmo1FsgohbJQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/upload-client/-/upload-client-5.3.0.tgz",
+      "integrity": "sha512-3vLErJTiigQ/cSlg8mCrOz3ZV1AZeGgeKDvmDhOBSaIY5rBvKzW2Bjcu4Vqv1cLdWOz2qkg6Tp6X+0qRV0cfPA==",
       "requires": {
         "@ipld/car": "^5.0.0",
         "@ipld/dag-ucan": "^3.0.1",
         "@ipld/unixfs": "^2.0.0",
-        "@ucanto/client": "^4.0.2",
-        "@ucanto/interface": "^4.0.2",
-        "@ucanto/transport": "^4.0.2",
+        "@ucanto/client": "^4.0.3",
+        "@ucanto/interface": "^4.0.3",
+        "@ucanto/transport": "^4.0.3",
         "@web3-storage/capabilities": "^2.1.0",
         "multiformats": "^10.0.2",
         "p-queue": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@ucanto/transport": "^4.0.2",
     "@web3-storage/access": "^9.1.1",
     "@web3-storage/capabilities": "^2.0.0",
-    "@web3-storage/upload-client": "^5.2.0"
+    "@web3-storage/upload-client": "^5.3.0"
   },
   "devDependencies": {
     "@ucanto/server": "^4.0.2",

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,4 @@
-import { uploadFile, uploadDirectory } from '@web3-storage/upload-client'
+import { uploadFile, uploadDirectory, uploadCAR } from '@web3-storage/upload-client'
 import { Store as StoreCapabilities, Upload as UploadCapabilities } from '@web3-storage/capabilities'
 import { Base } from './base.js'
 import { Space } from './space.js'
@@ -47,6 +47,24 @@ export class Client extends Base {
     const conf = await this._invocationConfig([StoreCapabilities.add.can, UploadCapabilities.add.can])
     options.connection = this._serviceConf.upload
     return uploadDirectory(conf, files, options)
+  }
+
+  /**
+   * Uploads a CAR file to the service.
+   *
+   * The difference between this function and `capability.store.add` is that the
+   * CAR file is automatically sharded and an "upload" is registered, linking
+   * the individual shards (see `capability.upload.add`).
+   *
+   * Use the `onShardStored` callback to obtain the CIDs of the CAR file shards.
+   *
+   * @param {import('./types').BlobLike} car CAR file.
+   * @param {import('./types').UploadOptions} [options]
+   */
+  async uploadCAR (car, options = {}) {
+    const conf = await this._invocationConfig([StoreCapabilities.add.can, UploadCapabilities.add.can])
+    options.connection = this._serviceConf.upload
+    return uploadCAR(conf, car, options)
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export type {
   RequestOptions,
   ListRequestOptions,
   ShardingOptions,
+  ShardStoringOptions,
   UploadOptions,
   FileLike,
   BlobLike


### PR DESCRIPTION
Propagates the change in https://github.com/web3-storage/w3protocol/pull/329.

The PR adds an `uploadCAR` function to the client.

It differs from `capability.store.add` because it automatically shards the CAR file, calls `capability.store.add` for each shard and finally registers an upload (using `capability.upload.add`). This is very similar to `uploadFile` or `uploadDirectory` except it skips the UnixFS encoding step.