### PR TITLE
feat: bring your own principal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,14 @@ import { Client } from './client.js'
 export async function create (options = {}) {
   const store = options.store ?? new StoreIndexedDB('w3up-client')
   const raw = await store.load()
-  if (raw) return new Client(AgentData.fromExport(raw, { store }), options)
-  const principal = await generate()
+  if (raw) {
+    const data = AgentData.fromExport(raw, { store })
+    if (options.principal && data.principal.did() !== options.principal.did()) {
+      throw new Error(`store cannot be used with ${options.principal.did()}, stored principal and passed principal must match`)
+    }
+    return new Client(data, options)
+  }
+  const principal = options.principal ?? await generate()
   const data = await AgentData.create({ principal }, { store })
   return new Client(data, options)
 }

--- a/src/index.node.js
+++ b/src/index.node.js
@@ -24,8 +24,14 @@ import { Client } from './client.js'
 export async function create (options = {}) {
   const store = options.store ?? new StoreConf({ profile: 'w3up-client' })
   const raw = await store.load()
-  if (raw) return new Client(AgentData.fromExport(raw, { store }), options)
-  const principal = await generate()
+  if (raw) {
+    const data = AgentData.fromExport(raw, { store })
+    if (options.principal && data.principal.did() !== options.principal.did()) {
+      throw new Error(`store cannot be used with ${options.principal.did()}, stored principal and passed principal must match`)
+    }
+    return new Client(data, options)
+  }
+  const principal = options.principal ?? await generate()
   const data = await AgentData.create({ principal }, { store })
   return new Client(data, options)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Driver } from '@web3-storage/access/drivers/types'
 import { Service as AccessService, AgentDataExport } from '@web3-storage/access/types'
 import { Service as UploadService } from '@web3-storage/upload-client/types'
-import { ConnectionView } from '@ucanto/interface'
+import { ConnectionView, Signer } from '@ucanto/interface'
 import { Client } from './client'
 
 export interface ServiceConf {
@@ -18,6 +18,12 @@ export interface ClientFactoryOptions {
    * Service DID and URL configuration.
    */
   serviceConf?: ServiceConf
+  /**
+   * Use this principal to sign UCANs. Note: if the store is non-empty and the
+   * principal saved in the store is not the same principal as the one passed
+   * here an error will be thrown.
+   */
+  principal?: Signer
 }
 
 export interface ClientFactory {

--- a/test/index.node.test.js
+++ b/test/index.node.test.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import { EdDSA } from '@ipld/dag-ucan/signature'
 import { StoreConf } from '@web3-storage/access/stores/store-conf'
 import { create } from '../src/index.node.js'
+import { Signer } from '@ucanto/principal/ed25519'
 
 describe('create', () => {
   it('should create Ed25519 key', async () => {
@@ -19,5 +20,29 @@ describe('create', () => {
     const client1 = await create({ store })
 
     assert.equal(client0.agent().did(), client1.agent().did())
+  })
+
+  it('should allow BYO principal', async () => {
+    const store = new StoreConf({ profile: 'w3up-client-test' })
+    await store.reset()
+
+    const principal = await Signer.generate()
+    const client = await create({ principal, store })
+
+    assert.equal(client.agent().did(), principal.did())
+  })
+
+  it('should throw for mismatched BYO principal', async () => {
+    const store = new StoreConf({ profile: 'w3up-client-test' })
+    await store.reset()
+
+    const principal0 = await Signer.generate()
+    await create({ principal: principal0, store })
+
+    const principal1 = await Signer.generate()
+    await assert.rejects(
+      create({ principal: principal1, store }),
+      { message: `store cannot be used with ${principal1.did()}, stored principal and passed principal must match` }
+    )
   })
 })


### PR DESCRIPTION
This PR allows passing your own principal to the client `create` factory function instead of loading one from a pre-existing store. The caveat is that if you pass your own and the store is not empty then it needs to match the principal that was loaded from the store (otherwise any saved delegations will be unusable).

This makes https://gist.github.com/alanshaw/e949abfcf6728f590ac9fa083dba5648#on-the-server a little easier, you won't need to install `@web3-storage/access` or deal with the `AgentData` class.

Currently:

```js
import * as Signer from '@ucanto/principal/ed25519'
import { AgentData } from '@web3-storage/access/agent'
import { Client } from '@web3-storage/w3up-client'

const principal = Signer.parse(process.env.KEY)
const data = await AgentData.create({ principal })
const client = new Client(data)
```

After this PR:

```js
import * as Signer from '@ucanto/principal/ed25519'
import * as Client from '@web3-storage/w3up-client'

const principal = Signer.parse(process.env.KEY)
const client = await Client.create({ principal })
```